### PR TITLE
Bugfix Guest Order Placement via Soap Api

### DIFF
--- a/src/app/code/community/Mage/Debit/Model/Observer.php
+++ b/src/app/code/community/Mage/Debit/Model/Observer.php
@@ -139,9 +139,15 @@ class Mage_Debit_Model_Observer
     public function _getOrderCustomer($order)
     {
         if (Mage::app()->getStore()->isAdmin()) {
+            
             if ($customer = $order->getCustomer()) {
-                return $customer;
+                
+                if ($customer->getId()) { 
+                    return $customer;
+                }                   
+                
             }
+            
         } else {
             $customer = Mage::getSingleton('customer/session')->getCustomer();
             if ($customer->getId()) {


### PR DESCRIPTION
Api Use Case - Community Edition 1.6.2 - Soap V1 interface:
- Mage::app()->getStore()->isAdmin() returns true
- $customer is used from the $order object

In the case of an 'guest' order, the validation of the $customer failed, 
because it contains no data. To make it work properly, added the getId check also.
Ohterwise return null.
