### PR TITLE
Add magento-composer-installer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,8 @@
             "name": "Rouven Alexander Rieker",
             "email": "therouv@googlemail.com"
         }
-   ]
+   ],
+   "require":{
+        "magento-hackathon/magento-composer-installer":"*"
+    }
 }


### PR DESCRIPTION
Without this dependency the module won't by installable via composer.
Well, if another module happens to require it, it will work. But on
it's own it won't. :)
