### PR TITLE
Update blzcheck.js

### DIFF
--- a/src/js/itabs/debit/blzcheck.js
+++ b/src/js/itabs/debit/blzcheck.js
@@ -75,7 +75,7 @@ Event.observe(window, 'load', function() {
     });
 
     Validation.add('validate-debit-number',  Translator.translate('Please enter a valid bank acount number.'), function(v) {
-        if (v.length > 4 && v.length < 11) {
+        if (v.length > 4 && v.length <= 11) {
             return true;
         }
         return false;


### PR DESCRIPTION
maxlength of input field #kontonummer is 11, therefor an error occurs when entering an account number with 11 digits
