### PR TITLE
Changed class constant and fixed possible typo

### DIFF
--- a/src/app/code/community/Itabs/Debit/sql/debit_setup/mysql4-upgrade-0.5.2-1.0.0.php
+++ b/src/app/code/community/Itabs/Debit/sql/debit_setup/mysql4-upgrade-0.5.2-1.0.0.php
@@ -87,8 +87,8 @@ $installer->getConnection()->addColumn(
     $installer->getTable('sales/quote_payment'),
     'debit_swift',
     array(
-        'type' => Varien_Db_Ddl_Table::TYPE_TEXT,
-        'lenght' => 255,
+        'type' => Varien_Db_Ddl_Table::TYPE_VARCHAR,
+        'length' => 255,
         'comment' => 'Debit Swift Code'
     )
 );
@@ -97,8 +97,8 @@ $installer->getConnection()->addColumn(
     $installer->getTable('sales/quote_payment'),
     'debit_iban',
     array(
-        'type' => Varien_Db_Ddl_Table::TYPE_TEXT,
-        'lenght' => 255,
+        'type' => Varien_Db_Ddl_Table::TYPE_VARCHAR,
+        'length' => 255,
         'comment' => 'Debit IBAN'
     )
 );
@@ -107,8 +107,8 @@ $installer->getConnection()->addColumn(
     $installer->getTable('sales/quote_payment'),
     'debit_type',
     array(
-        'type' => Varien_Db_Ddl_Table::TYPE_TEXT,
-        'lenght' => 4,
+        'type' => Varien_Db_Ddl_Table::TYPE_VARCHAR,
+        'length' => 4,
         'comment' => 'Debit Type'
     )
 );
@@ -117,8 +117,8 @@ $installer->getConnection()->addColumn(
     $installer->getTable('sales/order_payment'),
     'debit_swift',
     array(
-        'type' => Varien_Db_Ddl_Table::TYPE_TEXT,
-        'lenght' => 255,
+        'type' => Varien_Db_Ddl_Table::TYPE_VARCHAR,
+        'length' => 255,
         'comment' => 'Debit Swift Code'
     )
 );
@@ -127,8 +127,8 @@ $installer->getConnection()->addColumn(
     $installer->getTable('sales/order_payment'),
     'debit_iban',
     array(
-        'type' => Varien_Db_Ddl_Table::TYPE_TEXT,
-        'lenght' => 255,
+        'type' => Varien_Db_Ddl_Table::TYPE_VARCHAR,
+        'length' => 255,
         'comment' => 'Debit IBAN'
     )
 );
@@ -137,8 +137,8 @@ $installer->getConnection()->addColumn(
     $installer->getTable('sales/order_payment'),
     'debit_type',
     array(
-        'type' => Varien_Db_Ddl_Table::TYPE_TEXT,
-        'lenght' => 4,
+        'type' => Varien_Db_Ddl_Table::TYPE_VARCHAR,
+        'length' => 4,
         'comment' => 'Debit Type'
     )
 );
@@ -148,8 +148,8 @@ $installer->getConnection()->addColumn(
     $installer->getTable('debit/order_grid'),
     'debit_type',
     array(
-        'type' => Varien_Db_Ddl_Table::TYPE_TEXT,
-        'lenght' => 4,
+        'type' => Varien_Db_Ddl_Table::TYPE_VARCHAR,
+        'length' => 4,
         'comment' => 'Debit Type'
     )
 );


### PR DESCRIPTION
The class constant `TYPE_TEXT` does not exist in Magento Professional 1.10, but `TYPE_VARCHAR` does. It also exists in Magento CE 1.7.0.2 and CE 1.8.0.0 despite being marked as deprecated, so I'm thinking it can be used safely.
Also there seems to be a typo: lenght instead of length.
