### PR TITLE
Fix handling of SWIFT-Codes with a length of eight characters

### DIFF
--- a/src/js/itabs/debit/blzcheck.js
+++ b/src/js/itabs/debit/blzcheck.js
@@ -36,6 +36,11 @@ blzAjaxCheck.prototype = {
         } else {
             param = $('swiftcode').value;
             identifier = 'swift';
+
+            if (8 == param.length) {
+                param = param + 'XXX';
+                $('swiftcode').setValue(param);
+            }
         }
 
         new Ajax.Request(


### PR DESCRIPTION
SWIFT-Codes can be 8 or 11 characters long (see http://de.wikipedia.org/wiki/SWIFT#SWIFT-Code). If the 'short' version is used, append 'XXX' to pass js validation and fetch the correct bank name