### PR TITLE
prevent double encryption of debit data

### DIFF
--- a/src/app/code/community/Itabs/Debit/Model/Observer.php
+++ b/src/app/code/community/Itabs/Debit/Model/Observer.php
@@ -89,6 +89,12 @@ class Itabs_Debit_Model_Observer
                 ->setData('debit_payment_account_swift', $methodInstance->getAccountSwift())
                 ->setData('debit_payment_account_iban', $methodInstance->getAccountIban())
                 ->save();
+            $customer->unsetData('debit_payment_acount_update');
+            $customer->unsetData('debit_payment_acount_name');
+            $customer->unsetData('debit_payment_acount_number');
+            $customer->unsetData('debit_payment_acount_blz');
+            $customer->unsetData('debit_payment_account_swift');
+            $customer->unsetData('debit_payment_account_iban');
         }
     }
 


### PR DESCRIPTION
fixes issue #78 

Im sales_order_save_after event werden die Bankdaten gespeichert.
$customer->setData ....
    ->setData.....
    ->save();

$customer->save() wird durch ein anderes Event nochmal aufgerufen, die hier schon verschlüsselten Daten werden erneut verschlüsselt.

$customer->unsetData(...) verhindert dies.
